### PR TITLE
chore: overload deprecated AccessorSignatures

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -2509,15 +2509,15 @@ inline void SetPrototypeMethod(
 
 //=== Accessors and Such =======================================================
 
-inline void SetAccessor(
+NAN_DEPRECATED inline void SetAccessor(
     v8::Local<v8::ObjectTemplate> tpl
   , v8::Local<v8::String> name
   , GetterCallback getter
-  , SetterCallback setter = 0
-  , v8::Local<v8::Value> data = v8::Local<v8::Value>()
-  , v8::AccessControl settings = v8::DEFAULT
-  , v8::PropertyAttribute attribute = v8::None
-  , imp::Sig signature = imp::Sig()) {
+  , SetterCallback setter
+  , v8::Local<v8::Value> data
+  , v8::AccessControl settings
+  , v8::PropertyAttribute attribute
+  , imp::Sig signature) {
   HandleScope scope;
 
   imp::NativeGetter getter_ =
@@ -2553,6 +2553,49 @@ inline void SetAccessor(
 #if (NODE_MODULE_VERSION < NODE_18_0_MODULE_VERSION)
     , signature
 #endif
+  );
+}
+
+inline void SetAccessor(
+    v8::Local<v8::ObjectTemplate> tpl
+  , v8::Local<v8::String> name
+  , GetterCallback getter
+  , SetterCallback setter = 0
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()
+  , v8::AccessControl settings = v8::DEFAULT
+  , v8::PropertyAttribute attribute = v8::None) {
+  HandleScope scope;
+
+  imp::NativeGetter getter_ =
+      imp::GetterCallbackWrapper;
+  imp::NativeSetter setter_ =
+      setter ? imp::SetterCallbackWrapper : 0;
+
+  v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
+  otpl->SetInternalFieldCount(imp::kAccessorFieldCount);
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
+
+  obj->SetInternalField(
+      imp::kGetterIndex
+    , New<v8::External>(reinterpret_cast<void *>(getter)));
+
+  if (setter != 0) {
+    obj->SetInternalField(
+        imp::kSetterIndex
+      , New<v8::External>(reinterpret_cast<void *>(setter)));
+  }
+
+  if (!data.IsEmpty()) {
+    obj->SetInternalField(imp::kDataIndex, data);
+  }
+
+  tpl->SetAccessor(
+      name
+    , getter_
+    , setter_
+    , obj
+    , settings
+    , attribute
   );
 }
 

--- a/nan_callbacks.h
+++ b/nan_callbacks.h
@@ -52,7 +52,9 @@ typedef void(*IndexQueryCallback)(
     const PropertyCallbackInfo<v8::Integer>&);
 
 namespace imp {
-typedef v8::Local<v8::AccessorSignature> Sig;
+#if (NODE_MODULE_VERSION < NODE_18_0_MODULE_VERSION)
+NAN_DEPRECATED typedef v8::Local<v8::AccessorSignature> Sig;
+#endif
 
 static const int kDataIndex =                    0;
 


### PR DESCRIPTION
I created this fork so that I can generate the npm package which I need. Credits to VerteDinde for the changes (I coulnd't find an npm package for her changes, which I need).